### PR TITLE
New line heights

### DIFF
--- a/src/override-config.js
+++ b/src/override-config.js
@@ -1,5 +1,9 @@
 import {theme} from 'tailwindcss/stubs/config.full';
 
+const calculatedLineHeight = (lineHeight) => {
+  return `max(1em, ${lineHeight} * min(4em / 9 + 2rem / 3, min((2em + 1rem) / 3, (4em - 1rem) / 3)))`;
+}
+
 export default {
   theme: {
     // Remove line height from font sizes
@@ -9,11 +13,11 @@ export default {
     })),
     // Merge line height with defaults
     lineHeight: Object.assign(theme.lineHeight, {
-      tight: 'min(1.25em, 1em + .25rem)',
-      snug: 'min(1.375em, 1em + .375rem)',
-      normal: 'min(1.5em, 1em + .5rem)',
-      relaxed: 'min(1.625em, 1em + .625rem)',
-      loose: 'min(2em, 1em + 1rem)',
+      tight: calculatedLineHeight(1.25),
+      snug: calculatedLineHeight(1.375),
+      normal: calculatedLineHeight(1.5),
+      relaxed: calculatedLineHeight(1.625),
+      loose: calculatedLineHeight(2),
     }),
   },
   corePlugins: {


### PR DESCRIPTION
The new line heights are more in sync with Tailwinds default line heights, except for `lg`, which looks a little too large in Tailwind itself. 

![Relative line-height (1)](https://github.com/user-attachments/assets/8c47ca2f-9f50-4dd9-ad45-6a4009d86294)
